### PR TITLE
Don't rename .js files to .j

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ var reactTools = require('react-tools')
 
 function factory(args, config, logger, helper) {
 	return function(content, file, done) {
-		file.path = file.originalPath.slice(0, -1)
+		if (file.originalPath.substr(-4) == '.jsx') {
+			file.path = file.originalPath.slice(0, -1);
+		}
 		done(reactTools.transform(content))
 	}
 }

--- a/test/unit/preprocessor.js
+++ b/test/unit/preprocessor.js
@@ -55,6 +55,17 @@ describe('unit/preprocessor.js', function() {
 				file.path
 					.should.equal('abc.js')
 			})
+			it('should keep .js file extension', function() {
+				file =
+					{ path: 'abc.js'
+					, originalPath: 'abc.js'
+					}
+				reactTools.transform.returns('transformed content')
+				callback = fzkes.fake('callback')
+				result('content', file, callback)
+				file.path
+					.should.equal('abc.js')
+			})
 		})
 	})
 })


### PR DESCRIPTION
For various reasons, the jsx files in my project have a .js extension, and the react preprocessor was giving the processed files a .j extension, which caused problems with the karma-commonjs plugin.  This is the fix I got working to resolve my problem. 

Sorry about the duplication in the test--I'm sure there's a better way to organize it.
