### PR TITLE
ENH: Added doNotChangeFileExt to prevent changes from .jsx to .js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,24 @@
-module.exports =
-	{ 'preprocessor:react-jsx': ['factory', factory]
-	}
+module.exports = {
+  'preprocessor:react-jsx': ['factory', factory]
+}
 
-var reactTools = require('react-tools')
+var reactTools = require('react-tools');
 
 function factory(args, config, logger, helper) {
-	return function(content, file, done) {
-		if (file.originalPath.substr(-4) == '.jsx') {
-			file.path = file.originalPath.slice(0, -1);
-		}
-		done(reactTools.transform(content))
-	}
+  return function(content, file, done) {
+    // sometimes, it is better to just not change the file extension
+    // if you have a process that do something like this:
+    //
+    // var component = require('./some/component.jsx');
+    //
+    // and you want to test your commonjs module, then it will be better
+    // to not modify the file extension.
+    //
+
+    var cfg = config['react-jsx:preprocessor'] || {};
+    if (!cfg.doNotChangeFileExt && file.originalPath.substr(-4) == '.jsx') {
+      file.path = file.originalPath.slice(0, -1);
+    }
+    done(reactTools.transform(content))
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -19,5 +19,14 @@ will automatically transform the .jsx files.
 			},
 
 			// the rest of the config should be here
+
+			// configuring the preprocessor
+			'react-jsx:preprocessor' : {
+		        // by default the preprocessor will change the 
+		        // extension of the files from .jsx to .js.
+		        // This might be an issue in some situations.
+		        // Use this property to avoid the file to be renamed
+		        doNotChangeFileExt: true // default is false, change to true to prevent file extension change.
+		    }
 		})
 	}

--- a/test/unit/preprocessor.js
+++ b/test/unit/preprocessor.js
@@ -27,7 +27,7 @@ describe('unit/preprocessor.js', function() {
 		var result
 		beforeEach(function() {
 			factory = module['preprocessor:react-jsx'][1]
-			result = factory()
+			result = factory(null, {});
 		})
 		it('should return another function taking 3 arguments', function() {
 			result.should.be.a('function')
@@ -67,5 +67,27 @@ describe('unit/preprocessor.js', function() {
 					.should.equal('abc.js')
 			})
 		})
+    describe('when a configuration is provided', function () {
+      var callback
+      var file
+      beforeEach(function() {
+        file =
+        { path: 'abc.jsx'
+          , originalPath: 'abc.jsx'
+        }
+        reactTools.transform.returns('transformed content')
+        callback = fzkes.fake('callback')
+      })
+      it('should keep the .jsx extension if the config property doNotChangeExt is true', function () {
+        result = factory(null, {
+          'react-jsx:preprocessor': {
+            doNotChangeFileExt: true
+          }
+        });
+        result('content', file, callback)
+        file.path
+          .should.equal('abc.jsx')
+      });
+    });
 	})
 })


### PR DESCRIPTION
We use karma along with `karma-commonjs-plus` to run our unit tests. The default behavior of changing the fileName from .jsx to .js was breaking our code since the code have require calls like this

`require('./some/component.jsx');`

which were not longer valid after the transformation.

This pull request adds a property to the configuration object of this preprocessor. I'm using the preprocessor now from my fork. But it would be nice to use it from the official source, once you merge this pull request.

Regards
