### PR TITLE
Add transformPath option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,16 @@
 var reactTools = require('react-tools')
 
-function factory(args, config, logger, helper) {
+function createReactJsxPreprocessor(args, config, logger, helper) {
 	return function(content, file, done) {
 		if (file.originalPath.substr(-4) == '.jsx') {
 			file.path = file.originalPath.slice(0, -1);
 		}
-		done(reactTools.transform(content))
+		done(reactTools.transform(content));
 	}
 }
 
+
+createReactJsxPreprocessor.$inject = ['args', 'config.reactJsxPreprocessor', 'logger', 'helper'];
 module.exports = {
-	'preprocessor:react-jsx': ['factory', factory]
-}
+	'preprocessor:react-jsx': ['factory', createReactJsxPreprocessor]
+};

--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
-module.exports =
-	{ 'preprocessor:react-jsx': ['factory', factory]
-	}
-
 var reactTools = require('react-tools')
 
 function factory(args, config, logger, helper) {
@@ -11,4 +7,8 @@ function factory(args, config, logger, helper) {
 		}
 		done(reactTools.transform(content))
 	}
+}
+
+module.exports = {
+	'preprocessor:react-jsx': ['factory', factory]
 }

--- a/index.js
+++ b/index.js
@@ -1,16 +1,19 @@
 var reactTools = require('react-tools')
 
 function createReactJsxPreprocessor(args, config, logger, helper) {
+
+	config = config || {}
+	var transformPath = config.transformPath || function(path) {
+		return path.replace( /\.jsx$/,'.js')
+	}
 	return function(content, file, done) {
-		if (file.originalPath.substr(-4) == '.jsx') {
-			file.path = file.originalPath.slice(0, -1);
-		}
-		done(reactTools.transform(content));
+		file.path = transformPath(file.originalPath)
+		done(reactTools.transform(content))
 	}
 }
 
+createReactJsxPreprocessor.$inject = ['args', 'config.reactJsxPreprocessor', 'logger', 'helper']
 
-createReactJsxPreprocessor.$inject = ['args', 'config.reactJsxPreprocessor', 'logger', 'helper'];
-module.exports = {
-	'preprocessor:react-jsx': ['factory', createReactJsxPreprocessor]
-};
+module.exports =
+{ 'preprocessor:react-jsx': ['factory', createReactJsxPreprocessor]
+}

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,14 @@ will automatically transform the .jsx files.
 				'**/*.jsx': [ 'react-jsx' ]
 			},
 
+			reactJsxPreprocessor : {
+				// transforming the filenames
+	      transformPath: function(path) {
+	        return path.replace(/\.jsx$/, '.jsx.js');
+	      }
+
+    	}
+
 			// the rest of the config should be here
 		})
 	}

--- a/test/unit/preprocessor.js
+++ b/test/unit/preprocessor.js
@@ -51,20 +51,33 @@ describe('unit/preprocessor.js', function() {
 			it('should call the callback with the transformed content', function() {
 				callback.should.have.been.calledWith('transformed content')
 			})
-			it('should rename the file from .jsx to .js', function() {
-				file.path
-					.should.equal('abc.js')
-			})
-			it('should keep .js file extension', function() {
-				file =
-					{ path: 'abc.js'
-					, originalPath: 'abc.js'
-					}
-				reactTools.transform.returns('transformed content')
-				callback = fzkes.fake('callback')
-				result('content', file, callback)
-				file.path
-					.should.equal('abc.js')
+
+			describe('the file path', function(){
+				it('should be renamed by an optional transformPath function', function() {
+					result = factory(null, {
+						transformPath: function(fileName) {
+							return fileName.replace(/.jsx$/, '.jsx.js')
+						}
+					})
+					result('content', file, callback)
+					file.path
+					  .should.equal('abc.jsx.js')
+				})
+				it('should by default be renamed from .jsx to .js ', function() {
+					file.path
+						.should.equal('abc.js')
+				})
+				it('should by default keep .js file extension', function() {
+					file =
+						{ path: 'abc.js'
+						, originalPath: 'abc.js'
+						}
+					reactTools.transform.returns('transformed content')
+					callback = fzkes.fake('callback')
+					result('content', file, callback)
+					file.path
+						.should.equal('abc.js')
+				})
 			})
 		})
 	})


### PR DESCRIPTION
Allows users to configure the preprocessor with a function to transform the file path. 
Useful if you don't want the file name changed to `.js` but keeps the default behavior 
